### PR TITLE
Put default credentials in settings.xml

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <repository>
       <id>github</id>
       <name>GitHub OWNER Apache Maven Packages</name>
-      <url>https://jcansdale-robot:&#x31;&#x36;&#x31;&#x39;&#x37;&#x37;&#x36;&#x63;&#x36;&#x39;&#x36;&#x30;&#x33;&#x38;&#x66;&#x35;&#x32;&#x33;&#x30;&#x39;&#x39;&#x37;&#x63;&#x30;&#x35;&#x38;&#x39;&#x33;&#x64;&#x33;&#x33;&#x39;&#x61;&#x36;&#x34;&#x30;&#x30;&#x39;&#x66;&#x66;@maven.pkg.github.com/jcansdale-test/*</url>
+      <url>https://maven.pkg.github.com/jcansdale-test/*</url>
     </repository>
   </repositories>
 

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>jcansdale-robot</username>
+      <!-- Public token with `read:packages` scope -->
+      <password>&#x31;&#x36;&#x31;&#x39;&#x37;&#x37;&#x36;&#x63;&#x36;&#x39;&#x36;&#x30;&#x33;&#x38;&#x66;&#x35;&#x32;&#x33;&#x30;&#x39;&#x39;&#x37;&#x63;&#x30;&#x35;&#x38;&#x39;&#x33;&#x64;&#x33;&#x33;&#x39;&#x61;&#x36;&#x34;&#x30;&#x30;&#x39;&#x66;&#x66;</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
## Which this PR does

Instead of including a default PAT in the package repository URL like this:

```xml
  <repositories>
    <repository>
      <id>github</id>
      <name>GitHub OWNER Apache Maven Packages</name>
      <url>https://jcansdale-robot:&#x31;&#x36;&#x31;&#x39;&#x37...@maven.pkg.github.com/jcansdale-test/*</url>
    </repository>
  </repositories>
```

Add the `-s settings.xml` option to `.mvn/maven.config` and include the default credentials in an external `settings.xml` file:

```xml
<settings>
  <servers>
    <server>
      <id>github</id>
      <username>jcansdale-robot</username>
      <!-- Public token with `read:packages` scope -->
      <password>&#x31;&#x36;&#x31;&#x39;&#x37;&#x37;&#x36...</password>
    </server>
  </servers>
</settings>
```

This keeps the `pom.xml` file clean, but still allows users to simply `mvn package` after cloning.

```xml
  <repositories>
    <repository>
      <id>github</id>
      <name>GitHub OWNER Apache Maven Packages</name>
      <url>https://maven.pkg.github.com/jcansdale-test/*</url>
    </repository>
  </repositories>
```

*Note: I'm XML encoding the PAT (with `read:packages` scope) to prevent GitHub from automatically deleting it when it's spotted in a public repository. This is a workaround until public packages can be read using a scope-less PAT (which aren't automatically deleted).*