### PR TITLE
Try again with 1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.mycompany.app</groupId>
       <artifactId>my-app</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <name>consume-app</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <url>https://github.com/jcansdale/maven-consume</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Try again with snapshot version that was previously failing:
https://github.com/jcansdale-test/maven-consume/runs/475527611?check_suite_focus=true

```
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom (2.0 kB at 68 kB/s)
Downloading from github: https://maven.pkg.github.com/jcansdale-test/maven-test/com/mycompany/app/my-app/1.0-snapshot/my-app-1.0-snapshot.pom
Downloading from central: https://repo.maven.apache.org/maven2/com/mycompany/app/my-app/1.0-snapshot/my-app-1.0-snapshot.pom
[WARNING] The POM for com.mycompany.app:my-app:jar:1.0-snapshot is missing, no dependency information available
```

I don't know how/why it's now working!