### PR TITLE
Check if the REPOSITORY name is necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.mycompany.app</groupId>
       <artifactId>my-app</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.2.3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <repository>
       <id>github</id>
       <name>GitHub OWNER Apache Maven Packages</name>
-      <url>https://maven.pkg.github.com/jcansdale-test/maven-test</url>
+      <url>https://maven.pkg.github.com/jcansdale-test/*</url>
       <snapshots>
         <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>


### PR DESCRIPTION
It appears REPOSITORY is only necessary for SNAPSHOT versions. 😢 